### PR TITLE
Removes excessively long checkouts for staff

### DIFF
--- a/code/web/circll.php
+++ b/code/web/circll.php
@@ -206,7 +206,7 @@ if (!empty($duedate42)) {
 } else {
 	$duedate42 = clone $arrivesDate;
 	$duedate42 = $duedate42->add(new DateInterval("P42D"));
-	$duedate42 = findNextMNPSOpenDate($mnpsClosedDates, $duedate42);
+//	$duedate42 = findNextMNPSOpenDate($mnpsClosedDates, $duedate42); // commented out because we assume staff can handle their library business at NPL branches during breaks
 //	$duedate42 = min($duedate42, $endOfYearDueDate); // commented out because staff 42 day checkouts should ignore end-of-year due dates 'cause we assume staff can get to NPL branches during summer break
 }
 


### PR DESCRIPTION
... but still allows for transit time and closed dates before staff get their hands on the book. E.g., if an item goes into delivery Dec 17 and school is closed Dec 20-Jan 7, then the 42 day period will not start until Jan 8